### PR TITLE
resolve missing county label

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -344,7 +344,11 @@
             .attr("id", props.FIPS + "_label")
             .html(labelAttribute);
         
-        var countyName = infolabel.append("div")
+        var countyNameChart = infolabel.append("div")
+            .attr("class", "labelname")
+            .html(props.County);
+
+        var countyNameMap = infolabel.append("div")
             .attr("class", "labelname")
             .html(props.NAME);
 


### PR DESCRIPTION
This PR resolves the missing county label when hovering on the bar graph. Note that "name" attribute is not consistent across the two data sources (i.e., NAME v. County). 